### PR TITLE
Actualizar README con estructura unificada

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Serious Game para Celulares
+# Serious Game para EDS
 
 Este repositorio contiene cuatro mini-juegos educativos desarrollados en HTML, CSS y JavaScript. Ahora todos se integran en un único hub con registro de usuario y envío de puntajes a Google Sheets. El conjunto forma un *Serious Game* sobre **Educational Digital Storytelling** (EDS).
 
@@ -9,7 +9,7 @@ Este repositorio contiene cuatro mini-juegos educativos desarrollados en HTML, C
 - `03. Unir palabras/` – Juego de emparejar conceptos con sus definiciones.
 - `04. Ahorcado/` – Versión sencilla del juego del ahorcado con sistema de ranking.
 
-Cada carpeta mantiene su propio `index.html`, pero puedes acceder a ellos desde `index.html` en la raíz.
+Cada carpeta mantiene su propio `index.html`, pero puedes acceder a ellas desde `index.html` en la raíz.
 
 ## Uso rápido
 
@@ -19,7 +19,7 @@ Cada carpeta mantiene su propio `index.html`, pero puedes acceder a ellos desde 
 
 No es necesario instalar dependencias. Solo se requiere un navegador moderno con soporte para JavaScript.
 
-### Reiniciar progreso
+## Reiniciar progreso
 
 Abre la consola del navegador y ejecuta:
 
@@ -27,11 +27,11 @@ Abre la consola del navegador y ejecuta:
 localStorage.clear();
 ```
 
-### Cambiar el endpoint
+## Cambiar el endpoint de Google Sheets
 
 El envío de registros y puntajes usa el archivo `utils/sendScore.js`. Modifica la constante `ENDPOINT` o define la variable `VITE_SHEETS_ENDPOINT` si trabajas con un bundler.
 
-### Añadir nuevos mini-juegos
+## Añadir nuevos mini-juegos
 
 1. Crea una carpeta numerada (`05. Nombre/`).
 2. Coloca un `index.html` enlazando `../style.css` y usa módulos existentes (`gameState.js`, `sendScore.js`).


### PR DESCRIPTION
## Summary
- mantener frase clave de la rama main
- unificar secciones del README usando la estructura solicitada

## Testing
- `npx htmlhint '**/*.html'` *(falló: npm error canceled)*

------
https://chatgpt.com/codex/tasks/task_e_686edc5296b0832681a277f39eddca25