### PR TITLE
Fix navigation bar in register page

### DIFF
--- a/register.html
+++ b/register.html
@@ -20,9 +20,11 @@
 <script type="module">
 import { GameState } from './gameState.js';
 import { toggleDarkMode, loadDarkMode } from './theme.js';
+import { renderNav } from './nav.js';
 const form=document.getElementById('register-form');
 loadDarkMode();
 document.addEventListener('DOMContentLoaded',()=>{
+  renderNav('.');
   document.getElementById('dark-toggle').addEventListener('click',toggleDarkMode);
 });
 form.addEventListener('submit',async e=>{
@@ -44,11 +46,6 @@ form.addEventListener('submit',async e=>{
   location.href='index.html';
 });
 </script>
-  <nav class="bottom-nav">
-    <a href="register.html" aria-label="Registro">🤚</a>
-    <a href="index.html" aria-label="Juegos">🎮</a>
-    <a href="ranking.html" aria-label="Ranking">📊</a>
-    <button id="dark-toggle" aria-label="Tema oscuro" class="btn">🌙</button>
-  </nav>
+  <div id="nav-holder"></div>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- use `renderNav('.')` in *register.html* like other pages

## Testing
- `npx -y htmlhint '**/*.html'`

------
https://chatgpt.com/codex/tasks/task_e_687041e57150832686839f474ee2e02e